### PR TITLE
Added service trigger for mwan3 compatibility

### DIFF
--- a/ipk/data/etc/init.d/tailscale
+++ b/ipk/data/etc/init.d/tailscale
@@ -40,3 +40,14 @@ start_service() {
 stop_service() {
   /usr/sbin/tailscaled --cleanup
 }
+
+reload_service() {
+  echo "Restarting tailscale"
+  sleep 3
+  stop
+  start
+}
+
+service_triggers() {
+  procd_add_reload_trigger "mwan3"
+}


### PR DESCRIPTION
This adds a service trigger that detects a change in mwan3 to automatically trigger a reload in the tailscale service.

**This is important**, as without this trigger, tailscale is stuck without a connection when mwan3 is reloaded. For people that manage openwrt remotely this is extremely annoying.

Cheers,