### PR TITLE
Proper reloading of tailscale - Helps mwan3

### DIFF
--- a/ipk/data/etc/init.d/tailscale
+++ b/ipk/data/etc/init.d/tailscale
@@ -42,10 +42,9 @@ stop_service() {
 }
 
 reload_service() {
-  echo "Restarting tailscale"
-  sleep 3
-  stop
-  start
+  echo "Reloading tailscale"
+  /usr/sbin/tailscale down --accept-risk all --reason "Service Reload"
+  /usr/sbin/tailscale up
 }
 
 service_triggers() {


### PR DESCRIPTION
This does a proper reload.

When metric changes happen in mwan3, this approach is more reliable than a restart.

Why?

My theory is that  stop && start restarts the daemon but doesn't force a re-trigger of the ts routing caches.
But I reproduced the problem/solution reliably, and this is a cleaner reload anyway.